### PR TITLE
[fedora atomic k8s] Add boot from volume support

### DIFF
--- a/doc/source/user/index.rst
+++ b/doc/source/user/index.rst
@@ -344,8 +344,14 @@ the table are linked to more details elsewhere in the user guide.
 +---------------------------------------+--------------------+---------------+
 | `docker_volume_type`_                 | see below          | see below     |
 +---------------------------------------+--------------------+---------------+
+| `boot_volume_size`_                   | see below          | see below     |
++---------------------------------------+--------------------+---------------+
+| `boot_volume_type`_                   | see below          | see below     |
++---------------------------------------+--------------------+---------------+
 | `etcd_volume_size`_                   | etcd storage       | 0             |
 |                                       | volume size        |               |
++---------------------------------------+--------------------+---------------+
+| `etcd_volume_type`_                   | see below          | see below     |
 +---------------------------------------+--------------------+---------------+
 | `container_infra_prefix`_             | see below          | ""            |
 +---------------------------------------+--------------------+---------------+
@@ -1107,8 +1113,24 @@ _`admission_control_list`
   The default value corresponds to the one recommended in this doc
   for our current Kubernetes version.
 
+_`boot_volume_size`
+  This label sets the size of a boot volume for instances, this is useful if
+  your flavors are boot from volume only.  The default value is 20, setting
+  by config option default_boot_volume_size
+
+_`boot_volume_type`
+  This label sets the volume type of a boot volume for instances, this is
+  useful if your flavors are boot from volume only.  The default value is 0,
+  meaning that no volume will be created on boot. If it's not setting by
+  config option default_boot_volume_type, then Magnum will random select
+  one from the list of Cinder volume types.
+
 _`etcd_volume_size`
   This label sets the size of a volume holding the etcd storage data.
+  The default value is 0, meaning the etcd data is not persisted (no volume).
+
+_`etcd_volume_type`
+  This label sets the volume type of a volume holding the etcd storage data.
   The default value is 0, meaning the etcd data is not persisted (no volume).
 
 _`container_infra_prefix`

--- a/lower-constraints.txt
+++ b/lower-constraints.txt
@@ -117,6 +117,7 @@ python-barbicanclient==4.5.2
 python-dateutil==2.7.0
 python-editor==1.0.3
 python-glanceclient==2.8.0
+python-cinderclient==2.2.0
 python-heatclient==1.10.0
 python-keystoneclient==3.8.0
 python-mimeparse==1.6.0

--- a/magnum/common/cinder.py
+++ b/magnum/common/cinder.py
@@ -1,0 +1,46 @@
+# Copyright 2019 Catalyst Cloud Ltd.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from oslo_config import cfg
+from oslo_log import log as logging
+
+from magnum.common import clients
+from magnum.common import exception
+
+LOG = logging.getLogger(__name__)
+CONF = cfg.CONF
+
+
+def get_default_docker_volume_type(context):
+    return (CONF.cinder.default_docker_volume_type or
+            _get_random_volume_type(context))
+
+
+def get_default_boot_volume_type(context):
+    return (CONF.cinder.default_boot_volume_type or
+            _get_random_volume_type(context))
+
+
+def get_default_etcd_volume_type(context):
+    return (CONF.cinder.default_etcd_volume_type or
+            _get_random_volume_type(context))
+
+
+def _get_random_volume_type(context):
+    c_client = clients.OpenStackClients(context).cinder()
+    volume_types = c_client.volume_types.list()
+    if volume_types:
+        return volume_types[0].name
+    else:
+        raise exception.VolumeTypeNotFound()

--- a/magnum/common/exception.py
+++ b/magnum/common/exception.py
@@ -279,6 +279,12 @@ class OperationInProgress(Invalid):
                 "progress.")
 
 
+class VolumeTypeNotFound(ResourceNotFound):
+    """The code here changed to 400 according to the latest document."""
+    message = _("Valid volume type could not be found.")
+    code = 400
+
+
 class ImageNotFound(ResourceNotFound):
     """The code here changed to 400 according to the latest document."""
     message = _("Image %(image_id)s could not be found.")

--- a/magnum/conf/cinder.py
+++ b/magnum/conf/cinder.py
@@ -28,12 +28,53 @@ cinder_opts = [
                help=_('The default docker volume_type to use for volumes '
                       'used for docker storage. To use the cinder volumes '
                       'for docker storage, you need to select a default '
-                      'value.'))]
+                      'value. Otherwise, Magnum will select random one from '
+                      'Cinder volume type list.')),
+    cfg.StrOpt('default_etcd_volume_type',
+               default='',
+               help=_('The default etcd volume_type to use for volumes '
+                      'used for etcd storage. To use the cinder volumes '
+                      'for etcd storage, you need to select a default '
+                      'value. Otherwise, Magnum will select random one from '
+                      'Cinder volume type list.')),
+    cfg.StrOpt('default_boot_volume_type',
+               default='',
+               help=_('The default boot volume_type to use for volumes '
+                      'used for VM of COE. To use the cinder volumes '
+                      'for VM of COE, you need to select a default '
+                      'value. Otherwise, Magnum will select random one from '
+                      'Cinder volume type list.')),
+    cfg.IntOpt('default_boot_volume_size',
+               default=20,
+               help=_('The default volume size to use for volumes '
+                      'used for VM of COE.'))
+]
 
 cinder_client_opts = [
     cfg.StrOpt('region_name',
                help=_('Region in Identity service catalog to use for '
-                      'communication with the OpenStack service.'))]
+                      'communication with the OpenStack service.')),
+    cfg.StrOpt('endpoint_type',
+               default='publicURL',
+               help=_('Type of endpoint in Identity service catalog to use '
+                      'for communication with the OpenStack service.')),
+    cfg.StrOpt('api_version',
+               default='2',
+               help=_('Version of Cinder API to use in cinderclient.'))
+]
+
+common_security_opts = [
+    cfg.StrOpt('ca_file',
+               help=_('Optional CA cert file to use in SSL connections.')),
+    cfg.StrOpt('cert_file',
+               help=_('Optional PEM-formatted certificate chain file.')),
+    cfg.StrOpt('key_file',
+               help=_('Optional PEM-formatted file that contains the '
+                      'private key.')),
+    cfg.BoolOpt('insecure',
+                default=False,
+                help=_("If set, then the server's certificate will not "
+                       "be verified."))]
 
 
 def register_opts(conf):
@@ -41,6 +82,7 @@ def register_opts(conf):
     conf.register_group(cinder_client_group)
     conf.register_opts(cinder_opts, group=cinder_group)
     conf.register_opts(cinder_client_opts, group=cinder_client_group)
+    conf.register_opts(common_security_opts, group=cinder_client_group)
 
 
 def list_opts():

--- a/magnum/drivers/heat/k8s_fedora_template_def.py
+++ b/magnum/drivers/heat/k8s_fedora_template_def.py
@@ -15,6 +15,7 @@ import json
 from oslo_log import log as logging
 from oslo_utils import strutils
 
+from magnum.common import cinder
 from magnum.common import exception
 from magnum.common.x509 import operations as x509
 from magnum.conductor.handlers.common import cert_manager
@@ -91,11 +92,7 @@ class K8sFedoraTemplateDefinition(k8s_template_def.K8sTemplateDefinition):
         osc = self.get_osc(context)
         extra_params['region_name'] = osc.cinder_region_name()
 
-        # set docker_volume_type
-        # use the configuration default if None provided
-        docker_volume_type = cluster.labels.get(
-            'docker_volume_type', CONF.cinder.default_docker_volume_type)
-        extra_params['docker_volume_type'] = docker_volume_type
+        self._set_volumes(context, cluster, extra_params)
 
         extra_params['nodes_affinity_policy'] = \
             CONF.cluster.nodes_affinity_policy
@@ -161,6 +158,8 @@ class K8sFedoraTemplateDefinition(k8s_template_def.K8sTemplateDefinition):
 
         self._set_cert_manager_params(cluster, extra_params)
         self._get_keystone_auth_default_policy(extra_params)
+        self._set_volumes(context, cluster, extra_params)
+        extra_params['project_id'] = cluster.project_id
 
         return super(K8sFedoraTemplateDefinition,
                      self).get_params(context, cluster_template, cluster,
@@ -211,6 +210,28 @@ class K8sFedoraTemplateDefinition(k8s_template_def.K8sTemplateDefinition):
             washed_policy = default_policy.replace('"', '\"') \
                 .replace("$PROJECT_ID", extra_params["project_id"])
             extra_params["keystone_auth_default_policy"] = washed_policy
+
+    def _set_volumes(self, context, cluster, extra_params):
+        # set docker_volume_type
+        docker_volume_type = cluster.labels.get(
+            'docker_volume_type',
+            cinder.get_default_docker_volume_type(context))
+        extra_params['docker_volume_type'] = docker_volume_type
+
+        # set etcd_volume_type
+        etcd_volume_type = cluster.labels.get(
+            'etcd_volume_type', cinder.get_default_etcd_volume_type(context))
+        extra_params['etcd_volume_type'] = etcd_volume_type
+
+        # set boot_volume_type
+        boot_volume_type = cluster.labels.get(
+            'boot_volume_type', cinder.get_default_boot_volume_type(context))
+        extra_params['boot_volume_type'] = boot_volume_type
+
+        # set boot_volume_size
+        boot_volume_size = cluster.labels.get(
+            'boot_volume_size', CONF.cinder.default_boot_volume_size)
+        extra_params['boot_volume_size'] = boot_volume_size
 
     def get_env_files(self, cluster_template, cluster):
         env_files = []

--- a/magnum/drivers/k8s_fedora_atomic_v1/templates/kubecluster.yaml
+++ b/magnum/drivers/k8s_fedora_atomic_v1/templates/kubecluster.yaml
@@ -1,4 +1,4 @@
-heat_template_version: 2014-10-16
+heat_template_version: 2015-04-30
 
 description: >
   This template will boot a Kubernetes cluster with one or more
@@ -138,11 +138,26 @@ parameters:
     constraints:
       - allowed_values: ["true", "false"]
 
+  boot_volume_size:
+    type: number
+    description: >
+      size of the cinder boot volume for nodes root volume
+
+  boot_volume_type:
+    type: string
+    description: >
+      type of the cinder boot volume for nodes root volume
+
   etcd_volume_size:
     type: number
     description: >
       size of the cinder volume for etcd storage
     default: 0
+
+  etcd_volume_type:
+    type: string
+    description: >
+      type of a cinder volume for etcd storage
 
   docker_volume_size:
     type: number
@@ -850,7 +865,10 @@ resources:
           master_flavor: {get_param: master_flavor}
           external_network: {get_param: external_network}
           kube_allow_priv: {get_param: kube_allow_priv}
+          boot_volume_size: {get_param: boot_volume_size}
+          boot_volume_type: {get_param: boot_volume_type}
           etcd_volume_size: {get_param: etcd_volume_size}
+          etcd_volume_type: {get_param: etcd_volume_type}
           docker_volume_size: {get_param: docker_volume_size}
           docker_volume_type: {get_param: docker_volume_type}
           docker_storage_driver: {get_param: docker_storage_driver}
@@ -1029,6 +1047,8 @@ resources:
           etcd_server_ip: {get_attr: [etcd_address_lb_switch, private_ip]}
           external_network: {get_param: external_network}
           kube_allow_priv: {get_param: kube_allow_priv}
+          boot_volume_size: {get_param: boot_volume_size}
+          boot_volume_type: {get_param: boot_volume_type}
           docker_volume_size: {get_param: docker_volume_size}
           docker_volume_type: {get_param: docker_volume_type}
           docker_storage_driver: {get_param: docker_storage_driver}

--- a/magnum/drivers/k8s_fedora_atomic_v1/templates/kubemaster.yaml
+++ b/magnum/drivers/k8s_fedora_atomic_v1/templates/kubemaster.yaml
@@ -1,4 +1,4 @@
-heat_template_version: 2014-10-16
+heat_template_version: queens
 
 description: >
   This is a nested stack that defines a single Kubernetes master, This stack is
@@ -39,10 +39,26 @@ parameters:
     constraints:
       - allowed_values: ["true", "false"]
 
+  boot_volume_size:
+    type: number
+    description: >
+      size of the cinder boot volume for nodes root volume
+    default: 0
+
+  boot_volume_type:
+    type: string
+    description: >
+      type of the cinder boot volume for nodes root volume
+
   etcd_volume_size:
     type: number
     description: >
       size of a cinder volume to allocate for etcd storage
+
+  etcd_volume_type:
+    type: string
+    description: >
+      type of a cinder volume to allocate for etcd storage
 
   docker_volume_size:
     type: number
@@ -483,6 +499,15 @@ parameters:
     description: >
       maximum node count of cluster workers when doing scale up
 
+conditions:
+
+  image_based: {equals: [{get_param: boot_volume_size}, 0]}
+  volume_based:
+    not:
+      equals:
+      - get_param: boot_volume_size
+      - 0
+
 resources:
   ######################################################################
   #
@@ -650,11 +675,20 @@ resources:
   # a single kubernetes master.
   #
 
+  boot_volume:
+    type: OS::Cinder::Volume
+    condition: volume_based
+    properties:
+      image: {get_param: server_image}
+      size: {get_param: boot_volume_size}
+      volume_type: {get_param: boot_volume_type}
+
   # do NOT use "_" (underscore) in the Nova server name
   # it creates a mismatch between the generated Nova name and its hostname
   # which can lead to weird problems
   kube-master:
     type: OS::Nova::Server
+    condition: image_based
     properties:
       name: {get_param: name}
       image: {get_param: server_image}
@@ -667,6 +701,25 @@ resources:
         - port: {get_resource: kube_master_eth0}
       scheduler_hints: { group: { get_param: nodes_server_group_id }}
       availability_zone: {get_param: availability_zone}
+
+  kube-master:
+    type: OS::Nova::Server
+    condition: volume_based
+    properties:
+      name: {get_param: name}
+      flavor: {get_param: master_flavor}
+      key_name: {get_param: ssh_key_name}
+      user_data_format: SOFTWARE_CONFIG
+      software_config_transport: POLL_SERVER_HEAT
+      user_data: {get_resource: agent_config}
+      networks:
+        - port: {get_resource: kube_master_eth0}
+      scheduler_hints: { group: { get_param: nodes_server_group_id }}
+      availability_zone: {get_param: availability_zone}
+      block_device_mapping_v2:
+        - boot_index: 0
+          volume_id: {get_resource: boot_volume}
+          delete_on_termination: true
 
   kube_master_eth0:
     type: OS::Neutron::Port
@@ -712,6 +765,7 @@ resources:
     type: Magnum::Optional::Etcd::Volume
     properties:
       size: {get_param: etcd_volume_size}
+      volume_type: {get_param: etcd_volume_type}
 
   etcd_volume_attach:
     type: Magnum::Optional::Etcd::VolumeAttachment

--- a/magnum/drivers/k8s_fedora_atomic_v1/templates/kubeminion.yaml
+++ b/magnum/drivers/k8s_fedora_atomic_v1/templates/kubeminion.yaml
@@ -1,4 +1,4 @@
-heat_template_version: 2014-10-16
+heat_template_version: queens
 
 description: >
   This is a nested stack that defines a single Kubernetes minion, This stack is
@@ -33,6 +33,16 @@ parameters:
       whether or not kubernetes should permit privileged containers.
     constraints:
       - allowed_values: ["true", "false"]
+
+  boot_volume_size:
+    type: number
+    description: >
+      size of the cinder boot volume
+
+  boot_volume_type:
+    type: string
+    description: >
+      type of the cinder boot volume
 
   docker_volume_size:
     type: number
@@ -281,6 +291,15 @@ parameters:
     description: >
       true if the auto healing feature should be enabled
 
+conditions:
+
+  image_based: {equals: [{get_param: boot_volume_size}, 0]}
+  volume_based:
+    not:
+      equals:
+      - get_param: boot_volume_size
+      - 0
+
 resources:
 
   agent_config:
@@ -391,14 +410,38 @@ resources:
   # a single kubernetes minion.
   #
 
+  boot_volume:
+    type: OS::Cinder::Volume
+    condition: volume_based
+    properties:
+      image: {get_param: server_image}
+      size: {get_param: boot_volume_size}
+      volume_type: {get_param: boot_volume_type}
+
   # do NOT use "_" (underscore) in the Nova server name
   # it creates a mismatch between the generated Nova name and its hostname
   # which can lead to weird problems
   kube-minion:
+    condition: image_based
     type: OS::Nova::Server
     properties:
       name: {get_param: name}
+      flavor: {get_param: minion_flavor}
       image: {get_param: server_image}
+      key_name: {get_param: ssh_key_name}
+      user_data: {get_resource: agent_config}
+      user_data_format: SOFTWARE_CONFIG
+      software_config_transport: POLL_SERVER_HEAT
+      networks:
+        - port: {get_resource: kube_minion_eth0}
+      scheduler_hints: { group: { get_param: nodes_server_group_id }}
+      availability_zone: {get_param: availability_zone}
+
+  kube-minion:
+    condition: volume_based
+    type: OS::Nova::Server
+    properties:
+      name: {get_param: name}
       flavor: {get_param: minion_flavor}
       key_name: {get_param: ssh_key_name}
       user_data: {get_resource: agent_config}
@@ -408,6 +451,10 @@ resources:
         - port: {get_resource: kube_minion_eth0}
       scheduler_hints: { group: { get_param: nodes_server_group_id }}
       availability_zone: {get_param: availability_zone}
+      block_device_mapping_v2:
+        - boot_index: 0
+          volume_id: {get_resource: boot_volume}
+          delete_on_termination: true
 
   kube_minion_eth0:
     type: OS::Neutron::Port

--- a/magnum/tests/unit/conductor/handlers/test_k8s_cluster_conductor.py
+++ b/magnum/tests/unit/conductor/handlers/test_k8s_cluster_conductor.py
@@ -114,7 +114,8 @@ class TestClusterConductorWithK8s(base.TestCase):
                        'kubescheduler_options': '--kubescheduler',
                        'kubeproxy_options': '--kubeproxy',
                        'influx_grafana_dashboard_enabled': 'True',
-                       'service_cluster_ip_range': '10.254.0.0/16'},
+                       'service_cluster_ip_range': '10.254.0.0/16',
+                       'boot_volume_size': '60'},
             'master_flavor_id': 'master_flavor_id',
             'flavor_id': 'flavor_id',
             'project_id': 'project_id',
@@ -172,6 +173,10 @@ class TestClusterConductorWithK8s(base.TestCase):
         self.mock_enable_octavia = octavia_patcher.start()
         self.mock_enable_octavia.return_value = False
         self.addCleanup(octavia_patcher.stop)
+        CONF.set_override('default_boot_volume_type',
+                          'lvmdriver-1', group='cinder')
+        CONF.set_override('default_etcd_volume_type',
+                          'lvmdriver-1', group='cinder')
 
     @patch('requests.get')
     @patch('magnum.objects.ClusterTemplate.get_by_uuid')
@@ -259,6 +264,8 @@ class TestClusterConductorWithK8s(base.TestCase):
                        'kube_dashboard_enabled': 'True',
                        'influx_grafana_dashboard_enabled': 'True',
                        'docker_volume_type': 'lvmdriver-1',
+                       'boot_volume_type': 'lvmdriver-1',
+                       'etcd_volume_type': 'lvmdriver-1',
                        'etcd_volume_size': None,
                        'availability_zone': 'az_1',
                        'cert_manager_api': 'False',
@@ -345,7 +352,10 @@ class TestClusterConductorWithK8s(base.TestCase):
             'max_node_count': 2,
             'master_image': 'image_id',
             'minion_image': 'image_id',
-            'keystone_auth_default_policy': self.keystone_auth_default_policy
+            'keystone_auth_default_policy': self.keystone_auth_default_policy,
+            'boot_volume_size': '60',
+            'boot_volume_type': 'lvmdriver-1',
+            'etcd_volume_type': 'lvmdriver-1'
         }
         if missing_attr is not None:
             expected.pop(mapping[missing_attr], None)
@@ -484,7 +494,10 @@ class TestClusterConductorWithK8s(base.TestCase):
             'max_node_count': 2,
             'master_image': 'image_id',
             'minion_image': 'image_id',
-            'keystone_auth_default_policy': self.keystone_auth_default_policy
+            'keystone_auth_default_policy': self.keystone_auth_default_policy,
+            'boot_volume_size': '60',
+            'boot_volume_type': 'lvmdriver-1',
+            'etcd_volume_type': 'lvmdriver-1'
         }
 
         self.assertEqual(expected, definition)
@@ -603,7 +616,10 @@ class TestClusterConductorWithK8s(base.TestCase):
             'max_node_count': 2,
             'master_image': None,
             'minion_image': None,
-            'keystone_auth_default_policy': self.keystone_auth_default_policy
+            'keystone_auth_default_policy': self.keystone_auth_default_policy,
+            'boot_volume_size': '60',
+            'boot_volume_type': 'lvmdriver-1',
+            'etcd_volume_type': 'lvmdriver-1'
         }
         self.assertEqual(expected, definition)
         self.assertEqual(
@@ -1033,7 +1049,10 @@ class TestClusterConductorWithK8s(base.TestCase):
             'max_node_count': 2,
             'master_image': 'image_id',
             'minion_image': 'image_id',
-            'keystone_auth_default_policy': self.keystone_auth_default_policy
+            'keystone_auth_default_policy': self.keystone_auth_default_policy,
+            'boot_volume_size': '60',
+            'boot_volume_type': 'lvmdriver-1',
+            'etcd_volume_type': 'lvmdriver-1'
         }
         self.assertEqual(expected, definition)
         self.assertEqual(

--- a/magnum/tests/unit/drivers/test_template_definition.py
+++ b/magnum/tests/unit/drivers/test_template_definition.py
@@ -448,6 +448,8 @@ class AtomicK8sTemplateDefinitionTestCase(BaseK8sTemplateDefinitionTestCase):
             'influx_grafana_dashboard_enabled')
         docker_volume_type = mock_cluster.labels.get(
             'docker_volume_type')
+        boot_volume_size = mock_cluster.labels.get(
+            'boot_volume_size')
         etcd_volume_size = mock_cluster.labels.get(
             'etcd_volume_size')
         kube_tag = mock_cluster.labels.get('kube_tag')
@@ -530,6 +532,9 @@ class AtomicK8sTemplateDefinitionTestCase(BaseK8sTemplateDefinitionTestCase):
         max_node_count = mock_cluster.labels.get('max_node_count')
         master_image = mock_cluster_template.image_id
         minion_image = mock_cluster_template.image_id
+        boot_volume_size = mock_cluster.labels.get('boot_volume_size')
+        boot_volume_type = mock_cluster.labels.get('boot_volume_type')
+        etcd_volume_type = mock_cluster.labels.get('etcd_volume_type')
 
         k8s_def = k8sa_tdef.AtomicK8sTemplateDefinition()
 
@@ -549,6 +554,7 @@ class AtomicK8sTemplateDefinitionTestCase(BaseK8sTemplateDefinitionTestCase):
             'influx_grafana_dashboard_enabled':
                 influx_grafana_dashboard_enabled,
             'docker_volume_type': docker_volume_type,
+            'boot_volume_size': boot_volume_size,
             'etcd_volume_size': etcd_volume_size,
             'kubelet_options': kubelet_options,
             'kubeapi_options': kubeapi_options,
@@ -605,6 +611,9 @@ class AtomicK8sTemplateDefinitionTestCase(BaseK8sTemplateDefinitionTestCase):
             'master_image': master_image,
             'minion_image': minion_image,
             'kube_version': kube_tag,
+            'boot_volume_size': boot_volume_size,
+            'boot_volume_type': boot_volume_type,
+            'etcd_volume_type': etcd_volume_type
         }}
         mock_get_params.assert_called_once_with(mock_context,
                                                 mock_cluster_template,
@@ -851,6 +860,8 @@ class AtomicK8sTemplateDefinitionTestCase(BaseK8sTemplateDefinitionTestCase):
             'influx_grafana_dashboard_enabled')
         docker_volume_type = mock_cluster.labels.get(
             'docker_volume_type')
+        boot_volume_size = mock_cluster.labels.get(
+            'boot_volume_size')
         etcd_volume_size = mock_cluster.labels.get(
             'etcd_volume_size')
         kube_tag = mock_cluster.labels.get('kube_tag')
@@ -933,6 +944,9 @@ class AtomicK8sTemplateDefinitionTestCase(BaseK8sTemplateDefinitionTestCase):
         max_node_count = mock_cluster.labels.get('max_node_count')
         master_image = mock_cluster_template.image_id
         minion_image = mock_cluster_template.image_id
+        boot_volume_size = mock_cluster.labels.get('boot_volume_size')
+        boot_volume_type = mock_cluster.labels.get('boot_volume_type')
+        etcd_volume_type = mock_cluster.labels.get('etcd_volume_type')
 
         k8s_def = k8sa_tdef.AtomicK8sTemplateDefinition()
 
@@ -952,6 +966,7 @@ class AtomicK8sTemplateDefinitionTestCase(BaseK8sTemplateDefinitionTestCase):
             'influx_grafana_dashboard_enabled':
                 influx_grafana_dashboard_enabled,
             'docker_volume_type': docker_volume_type,
+            'boot_volume_size': boot_volume_size,
             'etcd_volume_size': etcd_volume_size,
             'kubelet_options': kubelet_options,
             'kubeapi_options': kubeapi_options,
@@ -1010,6 +1025,9 @@ class AtomicK8sTemplateDefinitionTestCase(BaseK8sTemplateDefinitionTestCase):
             'master_image': master_image,
             'minion_image': minion_image,
             'kube_version': kube_tag,
+            'boot_volume_size': boot_volume_size,
+            'boot_volume_type': boot_volume_type,
+            'etcd_volume_type': etcd_volume_type
         }}
         mock_get_params.assert_called_once_with(mock_context,
                                                 mock_cluster_template,

--- a/releasenotes/notes/boot-from-volume-7c73df68d7f325aa.yaml
+++ b/releasenotes/notes/boot-from-volume-7c73df68d7f325aa.yaml
@@ -1,0 +1,13 @@
+---
+features:
+  - |
+    Support boot from volume for Kubernetes all nodes (master and worker)
+    so that user can create a big size root volume, which could be more
+    flexible than using docker_volume_size. And user can specify the
+    volume type so that user can leverage high performance storage, e.g.
+    NVMe etc. And a new label etcd_volme_type is added as well so that
+    user can set volume type for etcd volume. If the boot_volume_type
+    or etcd_volume_type are not passed by labels, Magnum will try to
+    read them from config option default_boot_volume_type and
+    default_etcd_volume_type. A random volume type from Cinder will
+    be used if those options are not set.

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,6 +42,7 @@ pbr!=2.1.0,>=2.0.0 # Apache-2.0
 pecan!=1.0.2,!=1.0.3,!=1.0.4,!=1.2,>=1.0.0 # BSD
 pycadf!=2.0.0,>=1.1.0 # Apache-2.0
 python-barbicanclient>=4.5.2 # Apache-2.0
+python-cinderclient>=2.2.0 # Apache-2.0
 python-glanceclient>=2.8.0 # Apache-2.0
 python-heatclient>=1.10.0 # Apache-2.0
 python-neutronclient>=6.7.0 # Apache-2.0


### PR DESCRIPTION
Support boot from volume for Kubernetes all nodes (master and worker)
so that user can create a big size root volume, which could be more
flexible than using docker_volume_size. And user can specify the
volume type so that user can leverage high performance storage, e.g.
NVMe etc.

And a new label etcd_volme_type is added as well so that user can
set volume type for etcd volume.

If the boot_volume_type or etcd_volume_type are not passed by labels,
Magnum will try to read them from config option
default_boot_volume_type and default_etcd_volume_type. A random
volume type from Cinder will be used if those options are not set.

Task: 30374
Story: 2005386

Co-Authorized-By: Feilong Wang<flwang@catalyst.net.nz>

Change-Id: I39dd456bfa285bf06dd948d11c86867fc03d5afb