### PR TITLE
Fix Trust token scope for drivers

### DIFF
--- a/magnum/drivers/common/templates/kubernetes/fragments/make-cert-client.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/make-cert-client.sh
@@ -62,6 +62,11 @@ function generate_certificates {
                     "password": "$TRUSTEE_PASSWORD"
                 }
             }
+        },
+        "scope": {
+            "OS-TRUST:trust": {
+                "id": "$TRUST_ID"
+            }
         }
     }
 }

--- a/magnum/drivers/common/templates/kubernetes/fragments/make-cert.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/make-cert.sh
@@ -98,6 +98,11 @@ function generate_certificates {
                     "password": "$TRUSTEE_PASSWORD"
                 }
             }
+        },
+        "scope": {
+            "OS-TRUST:trust": {
+                "id": "$TRUST_ID"
+            }
         }
     }
 }

--- a/magnum/drivers/common/templates/swarm/fragments/make-cert.py
+++ b/magnum/drivers/common/templates/swarm/fragments/make-cert.py
@@ -161,6 +161,11 @@ def get_user_token(config, verify_ca):
                     "password": "%(trustee_password)s"
                 }
             }
+        },
+        "scope": {
+            "OS-TRUST:trust": {
+                "id": "$(trust_id)s"
+            }
         }
     }
 }
@@ -168,6 +173,7 @@ def get_user_token(config, verify_ca):
     params = {
         'trustee_user_id': config['TRUSTEE_USER_ID'],
         'trustee_password': config['TRUSTEE_PASSWORD'],
+        'trust_id': config['TRUST_ID'],
     }
     creds = creds_str % params
     headers = {'Content-Type': 'application/json'}

--- a/magnum/drivers/k8s_coreos_v1/templates/fragments/make-cert-client.yaml
+++ b/magnum/drivers/k8s_coreos_v1/templates/fragments/make-cert-client.yaml
@@ -73,6 +73,11 @@ write_files:
                           "password": "$TRUSTEE_PASSWORD"
                       }
                   }
+              },
+              "scope": {
+                  "OS-TRUST:trust": {
+                      "id": "$TRUST_ID"
+                  }
               }
           }
       }

--- a/magnum/drivers/k8s_coreos_v1/templates/fragments/make-cert.yaml
+++ b/magnum/drivers/k8s_coreos_v1/templates/fragments/make-cert.yaml
@@ -104,6 +104,11 @@ write_files:
                           "password": "$TRUSTEE_PASSWORD"
                       }
                   }
+              },
+              "scope": {
+                  "OS-TRUST:trust": {
+                      "id": "$TRUST_ID"
+                  }
               }
           }
       }


### PR DESCRIPTION
This fix driver token scope to make sure we use correct token scope from Trust.

This is work that follows
https://review.opendev.org/c/openstack/magnum/+/889144

In future, we should revert this fix and secure rbac patch once both are merged in openstack/magnum.

Change-Id: If5b31951959c7a141dc1cae5fefcabe4ebf438b3